### PR TITLE
Replace `merge-deep` with `lodash.merge`

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,5 +1,5 @@
 const React = require(`react`);
-const merge = require(`merge-deep`);
+const merge = require(`lodash.merge`);
 
 const getKey = (scope, key) => `gatsby-plugin-indieweb_${scope}_${key}`;
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "react": ">=16"
   },
   "dependencies": {
-    "merge-deep": "^3.0.2"
+    "lodash.merge": "^4.6.1"
   }
 }


### PR DESCRIPTION
`merge-deep` has a faulty dependency
(`clone-deep > lazy-cache > kind-of`)